### PR TITLE
Fixed issue where image index was getting calculated incorrectly

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Pod/Classes/CHImageScroller.swift
+++ b/Pod/Classes/CHImageScroller.swift
@@ -99,7 +99,7 @@ public class CHImageScroller: UIView, UIScrollViewDelegate {
     }
     
     public func viewForZoomingInScrollView(scrollView: UIScrollView) -> UIView? {
-        let imageIndex = scrollView.contentOffset.y/SCREEN_WIDTH
+        let imageIndex = scrollView.contentOffset.x/SCREEN_WIDTH
         return self.imageViews.objectAtIndex(Int(imageIndex)) as? UIView
     }
     


### PR DESCRIPTION
The index was getting calculated by divding the contentOffset.y by the screen width, but the scroller scrolls horizontally. Therefore it should be dividing the contentOffset.x.
